### PR TITLE
Grand child tests

### DIFF
--- a/Tests/SafeChildProcessHandleTests.cs
+++ b/Tests/SafeChildProcessHandleTests.cs
@@ -335,11 +335,13 @@ public partial class SafeChildProcessHandleTests
         processHandle.Kill();
     }
 
+#if WINDOWS || LINUX // It fails on macOS, as we use the poll on the exit pipe
     [Theory]
+    [InlineData(false)]
+#endif
 #if WINDOWS // https://github.com/adamsitnik/ProcessPlayground/issues/61
     [InlineData(true)]
 #endif
-    [InlineData(false)]
     public async Task WaitForExit_ReturnsWhenChildExits_EvenWithRunningGrandchild(bool useAsync)
     {
         // This test verifies that WaitForExitAsync returns when the direct child process exits,


### PR DESCRIPTION
Test for https://github.com/adamsitnik/ProcessPlayground/issues/61.

It's disabled on Unix for the async overload, as it simply fails