### PR TITLE
read lines async benchmarks: how channels affect perf

### DIFF
--- a/Benchmarks/RedirectToPipe.cs
+++ b/Benchmarks/RedirectToPipe.cs
@@ -19,8 +19,8 @@ public class RedirectToPipe
     {
         using (Process process = new())
         {
-            process.StartInfo.FileName = "dotnet";
-            process.StartInfo.Arguments = "--help";
+            process.StartInfo.FileName = "cmd";
+            process.StartInfo.Arguments = "/c for /L %i in (1,1,1000) do @echo Line %i";
             process.StartInfo.RedirectStandardOutput = true;
             process.StartInfo.RedirectStandardError = true;
             process.StartInfo.UseShellExecute = false;
@@ -44,8 +44,8 @@ public class RedirectToPipe
     {
         ProcessStartInfo info = new()
         {
-            FileName = "dotnet",
-            ArgumentList = { "--help" },
+            FileName = "cmd",
+            ArgumentList = { "/c", "for /L %i in (1,1,1000) do @echo Line %i" },
             RedirectStandardOutput = true,
             RedirectStandardError = true
         };
@@ -65,8 +65,8 @@ public class RedirectToPipe
     {
         ProcessStartInfo info = new()
         {
-            FileName = "dotnet",
-            ArgumentList = { "--help" },
+            FileName = "cmd",
+            ArgumentList = { "/c", "for /L %i in (1,1,1000) do @echo Line %i" },
             RedirectStandardOutput = true,
             RedirectStandardError = true
         };
@@ -88,8 +88,8 @@ public class RedirectToPipe
     {
         ProcessStartInfo info = new()
         {
-            FileName = "dotnet",
-            ArgumentList = { "--help" },
+            FileName = "cmd",
+            ArgumentList = { "/c", "for /L %i in (1,1,1000) do @echo Line %i" },
             RedirectStandardOutput = true,
             RedirectStandardError = true
         };

--- a/Benchmarks/RedirectToPipe.cs
+++ b/Benchmarks/RedirectToPipe.cs
@@ -3,6 +3,11 @@ using System.TBA;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using System;
+using System.Runtime.CompilerServices;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Channels;
 
 namespace Benchmarks;
 
@@ -35,56 +40,6 @@ public class RedirectToPipe
     }
 
     [Benchmark]
-    public async Task<int> OldReadLinesAsync()
-    {
-        ProcessStartInfo info = new()
-        {
-            FileName = "dotnet",
-            Arguments = "--help",
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false
-        };
-
-        using Process process = Process.Start(info)!;
-
-        Task<string?> readOutput = process.StandardOutput.ReadLineAsync();
-        Task<string?> readError = process.StandardError.ReadLineAsync();
-
-        while (true)
-        {
-            Task completedTask = await Task.WhenAny(readOutput, readError);
-
-            bool isError = completedTask == readError;
-            string? line = await(isError ? readError : readOutput);
-            if (line is null)
-            {
-                // Reached end of stream, let's consume the other stream fully
-                line = await (isError ? readOutput : readError);
-                while (line is not null)
-                {
-                    line = await (isError ? readOutput : readError);
-                }
-                break;
-            }
-
-            _ = line;
-
-            if (isError)
-            {
-                readError = process.StandardError.ReadLineAsync();
-            }
-            else
-            {
-                readOutput = process.StandardOutput.ReadLineAsync();
-            }
-        }
-
-        return process.ExitCode;
-    }
-
-#if NET
-    [Benchmark]
     public async Task<int> OldReadToEndAsync()
     {
         ProcessStartInfo info = new()
@@ -104,75 +59,199 @@ public class RedirectToPipe
 
         return process.ExitCode;
     }
-#endif
 
     [Benchmark]
-    public int NewReadLines()
+    public async Task<int> NoChannelsAsync()
     {
-        ProcessStartOptions info = new("dotnet")
+        ProcessStartInfo info = new()
         {
-            Arguments = { "--help" },
+            FileName = "dotnet",
+            ArgumentList = { "--help" },
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
         };
 
-        var lines = ChildProcess.StreamOutputLines(info);
-        foreach (var line in lines)
+        using Process process = Process.Start(info)!;
+
+        await foreach (var line in ReadAllLinesAsync(process))
         {
-            // We don't re-print, so the benchmark focuses on reading only.
-            _ = line.Content;
+            _ = line;
         }
-        return lines.ExitStatus.ExitCode;
+
+        await process.WaitForExitAsync();
+
+        return process.ExitCode;
     }
 
     [Benchmark]
-    public int NewCombinedOutput()
+    public async Task<int> ChannelsAsync()
     {
-        ProcessStartOptions info = new("dotnet")
+        ProcessStartInfo info = new()
         {
-            Arguments = { "--help" },
+            FileName = "dotnet",
+            ArgumentList = { "--help" },
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
         };
 
-        CombinedOutput output = ChildProcess.CaptureCombined(info);
-        return output.ExitStatus.ExitCode;
-    }
+        using Process process = Process.Start(info)!;
 
-    [Benchmark]
-    public int NewCombinedOutputTimeout()
-    {
-        ProcessStartOptions info = new("dotnet")
+        await foreach (var line in ReadAllLinesChannelAsync(process))
         {
-            Arguments = { "--help" },
-        };
-
-        CombinedOutput output = ChildProcess.CaptureCombined(info, timeout: TimeSpan.FromSeconds(3));
-        return output.ExitStatus.ExitCode;
-    }
-
-    [Benchmark]
-    public async Task<int> NewCombinedOutputAsync()
-    {
-        ProcessStartOptions info = new("dotnet")
-        {
-            Arguments = { "--help" },
-        };
-
-        CombinedOutput output = await ChildProcess.CaptureCombinedAsync(info);
-        return output.ExitStatus.ExitCode;
-    }
-
-    [Benchmark]
-    public async Task<int> NewReadLinesAsync()
-    {
-        ProcessStartOptions info = new("dotnet")
-        {
-            Arguments = { "--help" },
-        };
-
-        var lines = ChildProcess.StreamOutputLines(info);
-        await foreach (var line in lines)
-        {
-            // We don't re-print, so the benchmark focuses on reading only.
-            _ = line.Content;
+            _ = line;
         }
-        return lines.ExitStatus.ExitCode;
+
+        await process.WaitForExitAsync();
+
+        return process.ExitCode;
+    }
+
+    public async IAsyncEnumerable<ProcessOutputLine> ReadAllLinesAsync(Process process, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        StreamReader outputReader = process.StandardOutput;
+        StreamReader errorReader = process.StandardError;
+
+        using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        CancellationToken linkedToken = linkedCts.Token;
+
+        Task<string?> readOutput = outputReader.ReadLineAsync(linkedToken).AsTask();
+        Task<string?> readError = errorReader.ReadLineAsync(linkedToken).AsTask();
+        bool isError;
+
+        try
+        {
+            while (true)
+            {
+                Task completedTask = await Task.WhenAny(readOutput, readError).ConfigureAwait(false);
+
+                // When there is data available in both, handle error first.
+                isError = completedTask == readError || (readOutput.IsCompleted && readError.IsCompleted);
+
+                string? line = isError
+                    ? await readError.ConfigureAwait(false)
+                    : await readOutput.ConfigureAwait(false);
+
+                if (line is not null)
+                {
+                    yield return new ProcessOutputLine(line, isError);
+
+                    // Continue reading from the same stream while data is immediately available.
+                    StreamReader activeReader = isError ? errorReader : outputReader;
+                    while (true)
+                    {
+                        ValueTask<string?> nextRead = activeReader.ReadLineAsync(linkedToken);
+
+                        if (nextRead.IsCompleted)
+                        {
+                            line = await nextRead.ConfigureAwait(false);
+                            if (line is null)
+                            {
+                                break;
+                            }
+
+                            yield return new ProcessOutputLine(line, isError);
+                        }
+                        else
+                        {
+                            if (isError)
+                            {
+                                readError = nextRead.AsTask();
+                            }
+                            else
+                            {
+                                readOutput = nextRead.AsTask();
+                            }
+
+                            break;
+                        }
+                    }
+                }
+
+                if (line is null)
+                {
+                    break;
+                }
+            }
+
+            // One stream ended. Drain the remaining data from the other stream.
+            // isError tells us which stream returned null, so we drain the opposite stream.
+            string? moreData = await (isError ? readOutput : readError).ConfigureAwait(false);
+            StreamReader remainingReader = isError ? outputReader : errorReader;
+            bool remainingIsError = !isError;
+
+            while (moreData is not null)
+            {
+                yield return new ProcessOutputLine(moreData, remainingIsError);
+                moreData = await remainingReader.ReadLineAsync(linkedToken).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            // Cancel any in-flight reads when the consumer stops enumerating early
+            // (e.g., breaks out of await foreach without cancellation).
+            await linkedCts.CancelAsync().ConfigureAwait(false);
+
+            // Observe the pending tasks to prevent unobserved task exceptions.
+            // OperationCanceledException is expected from the cancellation above.
+            try { await readOutput.ConfigureAwait(false); }
+            catch (OperationCanceledException) { }
+
+            try { await readError.ConfigureAwait(false); }
+            catch (OperationCanceledException) { }
+        }
+    }
+
+    public async IAsyncEnumerable<ProcessOutputLine> ReadAllLinesChannelAsync(Process process, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        StreamReader outputReader = process.StandardOutput;
+        StreamReader errorReader = process.StandardError;
+
+        Channel<ProcessOutputLine> channel = Channel.CreateBounded<ProcessOutputLine>(0);
+        int completedCount = 0;
+
+        CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        Task outputTask = ReadToChannelAsync(outputReader, standardError: false, linkedCts.Token);
+        Task errorTask = ReadToChannelAsync(errorReader, standardError: true, linkedCts.Token);
+
+        try
+        {
+            await foreach (ProcessOutputLine line in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+            {
+                yield return line;
+            }
+        }
+        finally
+        {
+            await linkedCts.CancelAsync().ConfigureAwait(false);
+
+            // Ensure both tasks complete before disposing the CancellationTokenSource.
+            // The tasks handle all exceptions internally, so they always run to completion.
+            await outputTask.ConfigureAwait(false);
+            await errorTask.ConfigureAwait(false);
+
+            linkedCts.Dispose();
+        }
+
+        async Task ReadToChannelAsync(StreamReader reader, bool standardError, CancellationToken ct)
+        {
+            try
+            {
+                while (await reader.ReadLineAsync(ct).ConfigureAwait(false) is string line)
+                {
+                    await channel.Writer.WriteAsync(new ProcessOutputLine(line, standardError), ct).ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex)
+            {
+                channel.Writer.TryComplete(ex);
+                return;
+            }
+
+            if (Interlocked.Exchange(ref completedCount, 1) != 0)
+            {
+                channel.Writer.TryComplete();
+            }
+        }
     }
 }

--- a/Benchmarks/RedirectToPipe.cs
+++ b/Benchmarks/RedirectToPipe.cs
@@ -14,7 +14,7 @@ namespace Benchmarks;
 [BenchmarkCategory(nameof(RedirectToPipe))]
 public class RedirectToPipe
 {
-    [Benchmark(Baseline = true)]
+    [Benchmark]
     public int OldSyncEvents()
     {
         using (Process process = new())
@@ -84,7 +84,10 @@ public class RedirectToPipe
     }
 
     [Benchmark]
-    public async Task<int> ChannelsAsync()
+    [Arguments(0)]
+    [Arguments(5)]
+    [Arguments(10)]
+    public async Task<int> ChannelsAsync(int capacity)
     {
         ProcessStartInfo info = new()
         {
@@ -96,7 +99,7 @@ public class RedirectToPipe
 
         using Process process = Process.Start(info)!;
 
-        await foreach (var line in ReadAllLinesChannelAsync(process))
+        await foreach (var line in ReadAllLinesChannelAsync(capacity, process))
         {
             _ = line;
         }
@@ -201,12 +204,12 @@ public class RedirectToPipe
         }
     }
 
-    public async IAsyncEnumerable<ProcessOutputLine> ReadAllLinesChannelAsync(Process process, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public async IAsyncEnumerable<ProcessOutputLine> ReadAllLinesChannelAsync(int capacity, Process process, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         StreamReader outputReader = process.StandardOutput;
         StreamReader errorReader = process.StandardError;
 
-        Channel<ProcessOutputLine> channel = Channel.CreateBounded<ProcessOutputLine>(0);
+        Channel<ProcessOutputLine> channel = Channel.CreateBounded<ProcessOutputLine>(capacity);
         int completedCount = 0;
 
         CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);


### PR DESCRIPTION
```cmd
dotnet run -c Release -f net10.0 --filter *RedirectToPipe*
```

```ini
BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8246/25H2/2025Update/HudsonValley2)
AMD Ryzen Threadripper PRO 3945WX 12-Cores 3.99GHz, 1 CPU, 24 logical and 12 physical cores
.NET SDK 11.0.100-preview.4.26210.111
  [Host]     : .NET 10.0.6 (10.0.6, 10.0.626.17701), X64 RyuJIT x86-64-v3
  Job-IJTVWC : .NET 10.0.6 (10.0.6, 10.0.626.17701), X64 RyuJIT x86-64-v3
```

| Method            | Mean     | Ratio        | Completed Work Items | Allocated | Alloc Ratio |
|------------------ |---------:|-------------:|---------------------:|----------:|------------:|
| OldSyncEvents     | 209.4 ms |     baseline |               8.0000 | 112.08 KB |             |
| OldReadToEndAsync | 206.5 ms | 1.01x faster |               6.0000 |  89.59 KB |  1.25x less |
| NoChannelsAsync   | 196.7 ms | 1.06x faster |               4.0000 |  88.95 KB |  1.26x less |
| ChannelsAsync     | 201.9 ms | 1.04x faster |             119.0000 |  96.58 KB |  1.16x less |